### PR TITLE
抽選結果にCopy as Markdownボタンを追加

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -247,6 +247,20 @@ button {
   font-size: 1.5rem;
   margin-top: 0.6em;
 }
+.latest-lucky-user-dialog-actions {
+  margin-top: 0.4em;
+}
+.latest-lucky-user-dialog-copy-btn {
+  font-size: 0.7rem;
+  padding: 0.3em 0.8em;
+  border: 1px solid #ccc;
+  background: #f5f5f5;
+  border-radius: 0.3em;
+  cursor: pointer;
+}
+.latest-lucky-user-dialog-copy-btn:hover {
+  background: #e2e2e2;
+}
 .latest-lucky-user-dialog::backdrop {
   backdrop-filter: blur(2px) saturate(0%);
   background: #0002;

--- a/src/App.css
+++ b/src/App.css
@@ -248,6 +248,8 @@ button {
   margin-top: 0.6em;
 }
 .latest-lucky-user-dialog-actions {
+  display: flex;
+  justify-content: center;
   margin-top: 0.4em;
 }
 .latest-lucky-user-dialog-copy-btn {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import "./App.css";
 import { getUsersFromLocationHash, LuckyUser, setUsersToLocationHash, User } from "./users";
 
@@ -8,7 +8,20 @@ export function App({ initialUsers }: { initialUsers: User[] }) {
 
   const [isShowingLatestLuckyUser, setIsShowingLatestLuckyUser] =
     useState<boolean>(false);
+  const [copyButtonLabel, setCopyButtonLabel] = useState<string>("Copy as Markdown");
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const dialogRef = React.useRef<HTMLDialogElement>(null);
+
+  const copyAsMarkdown = useCallback(() => {
+    if (luckyUsers.length === 0) return;
+    const { user, beenLuckyAt } = luckyUsers[0];
+    const markdown = `**New Assignee**: id:${user.name} — ${beenLuckyAt.toLocaleString()}`;
+    navigator.clipboard.writeText(markdown).then(() => {
+      setCopyButtonLabel("Copied!");
+      clearTimeout(copyTimeoutRef.current);
+      copyTimeoutRef.current = setTimeout(() => setCopyButtonLabel("Copy as Markdown"), 2000);
+    });
+  }, [luckyUsers]);
 
   const setUserFromHash = useCallback(() => {
     setUsers(getUsersFromLocationHash());
@@ -97,6 +110,15 @@ export function App({ initialUsers }: { initialUsers: User[] }) {
             <div>id:{luckyUsers[0].user.name}</div>
             <div className="latest-lucky-user-dialog-date">
               {luckyUsers[0].beenLuckyAt.toLocaleString()}
+            </div>
+            <div className="latest-lucky-user-dialog-actions">
+              <button
+                onClick={copyAsMarkdown}
+                className="latest-lucky-user-dialog-copy-btn"
+                data-testid="copy-as-markdown-btn"
+              >
+                {copyButtonLabel}
+              </button>
             </div>
           </>
         ) : null}


### PR DESCRIPTION
結果をどこかに貼る際にコピーしたい需要がありましたので、コピーするボタンを追加しました。

動作の様子は以下のようになります。
https://github.com/7474/assign-omikuji-2020/pull/1#issuecomment-4765239494
><img width="897" height="1010" alt="image" src="https://github.com/user-attachments/assets/4ea9a032-acbb-45e2-b82d-1bd943500ec1" />
```
**New Assignee**: id:koudenpa — 6/22/2026, 12:39:29 PM
```

確認、取り込み検討お願いします。